### PR TITLE
Fixes error with vm_simple

### DIFF
--- a/roles/vm_provision/files/modules/vm_simple/vm.tf
+++ b/roles/vm_provision/files/modules/vm_simple/vm.tf
@@ -15,7 +15,7 @@ variable base_image {}
 
 resource "libvirt_volume" "image-node" {
   name = "${var.name}.img"
-  source = base_image
+  source = var.base_image
 }
 
 resource "libvirt_cloudinit_disk" "ci-node" {


### PR DESCRIPTION
Was getting "A reference to a resource type must be followed by at least one attribute"